### PR TITLE
Fixes #9 Repl is slow when displaying lots of coloured output

### DIFF
--- a/Product/ReplWindow/Repl/OutputBuffer.cs
+++ b/Product/ReplWindow/Repl/OutputBuffer.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Windows.Threading;
+using Microsoft.VisualStudio.Text;
 
 #if NTVS_FEATURE_INTERACTIVEWINDOW
 namespace Microsoft.NodejsTools.Repl {
@@ -241,11 +242,15 @@ namespace Microsoft.VisualStudio.Repl {
             }
 
             if (entries.Length > 0) {
-                for (int i = 0; i < entries.Length; i++) {
-                    var entry = entries[i];
-
-                    _window.AppendOutput(entry.Properties.Color, entry.Buffer.ToString(), i == entries.Length - 1);
+                var colors = new List<ColoredSpan>();
+                var text = new StringBuilder();
+                foreach (var entry in entries) {
+                    int start = text.Length;
+                    text.Append(entry.Buffer.ToString());
+                    colors.Add(new ColoredSpan(new Span(start, entry.Buffer.Length), entry.Properties.Color));
                 }
+                _window.AppendOutput(colors, text.ToString());
+
                 _window.TextView.Caret.EnsureVisible();
             }
         }

--- a/Product/ReplWindow/Repl/ReplOutputClassifier.cs
+++ b/Product/ReplWindow/Repl/ReplOutputClassifier.cs
@@ -54,6 +54,9 @@ namespace Microsoft.VisualStudio.Repl {
             if (startIndex < 0) {
                 startIndex = ~startIndex - 1;
             }
+            if (startIndex < 0) {
+                startIndex = 0;
+            }
 
             int spanEnd = span.End.Position;
             for (int i = startIndex; i < coloredSpans.Count && coloredSpans[i].Span.Start < spanEnd; i++) {

--- a/Product/ReplWindow/Repl/ReplOutputClassifier.cs
+++ b/Product/ReplWindow/Repl/ReplOutputClassifier.cs
@@ -51,11 +51,10 @@ namespace Microsoft.VisualStudio.Repl {
             List<ClassificationSpan> classifications = new List<ClassificationSpan>();
 
             int startIndex = coloredSpans.BinarySearch(new ColoredSpan(span, ConsoleColor.White), SpanStartComparer.Instance);
-            if (startIndex < 0) {
-                startIndex = ~startIndex - 1;
-            }
-            if (startIndex < 0) {
+            if (startIndex == -1) {
                 startIndex = 0;
+            } else if (startIndex < 0) {
+                startIndex = ~startIndex - 1;
             }
 
             int spanEnd = span.End.Position;


### PR DESCRIPTION
Fixes #9 Repl is slow when displaying lots of coloured output
Batches edits to the repl window buffer so that the updates all occur at once.
Removes unnecessary marshalling to the UI thread.
Fixes error when opening interactive window.