### PR TITLE
Fixes #4 Memory leaks in mock tests

### DIFF
--- a/Tests/MockVsTests/MockClassifierAggregatorService.cs
+++ b/Tests/MockVsTests/MockClassifierAggregatorService.cs
@@ -1,0 +1,74 @@
+﻿/* ****************************************************************************
+ *
+ * Copyright (c) Microsoft Corporation. 
+ *
+ * This source code is subject to terms and conditions of the Apache License, Version 2.0. A 
+ * copy of the license can be found in the License.html file at the root of this distribution. If 
+ * you cannot locate the Apache License, Version 2.0, please send an email to 
+ * vspython@microsoft.com. By using this source code in any fashion, you are agreeing to be bound 
+ * by the terms of the Apache License, Version 2.0.
+ *
+ * You must not remove this notice, or any other, from this software.
+ *
+ * ***************************************************************************/
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+
+namespace Microsoft.VisualStudioTools.MockVsTests {
+    [Export(typeof(IClassifierAggregatorService))]
+    public class MockClassifierAggregatorService : IClassifierAggregatorService {
+        [ImportMany]
+        internal IEnumerable<Lazy<IClassifierProvider, IContentTypeMetadata>> _providers = null;
+        
+        public IClassifier GetClassifier(ITextBuffer textBuffer) {
+            if (_providers == null) {
+                return null;
+            }
+
+            var contentType = textBuffer.ContentType;
+            return new AggregatedClassifier(
+                textBuffer,
+                _providers.Where(e => e.Metadata.ContentTypes.Any(c => contentType.IsOfType(c)))
+                    .Select(e => e.Value)
+            );
+        }
+
+        sealed class AggregatedClassifier : IClassifier, IDisposable {
+            private readonly ITextBuffer _buffer;
+            private readonly List<IClassifier> _classifiers;
+
+            public AggregatedClassifier(ITextBuffer textBuffer, IEnumerable<IClassifierProvider> providers) {
+                _buffer = textBuffer;
+                _classifiers = providers.Select(p => p.GetClassifier(_buffer)).ToList();
+            }
+
+            public void Dispose() {
+                foreach (var c in _classifiers.OfType<IDisposable>()) {
+                    c.Dispose();
+                }
+            }
+
+            public event EventHandler<ClassificationChangedEventArgs> ClassificationChanged {
+                add {
+                    foreach (var c in _classifiers) {
+                        c.ClassificationChanged += value;
+                    }
+                }
+                remove {
+                    foreach (var c in _classifiers) {
+                        c.ClassificationChanged -= value;
+                    }
+                }
+            }
+
+            public IList<ClassificationSpan> GetClassificationSpans(SnapshotSpan span) {
+                return _classifiers.SelectMany(c => c.GetClassificationSpans(span)).ToList();
+            }
+        }
+    }
+}

--- a/Tests/MockVsTests/MockCodeWindow.cs
+++ b/Tests/MockVsTests/MockCodeWindow.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         }
 
         public int GetEditorCaption(READONLYSTATUS dwReadOnly, out string pbstrEditorCaption) {
-            throw new NotImplementedException();
+            return GetPrimaryView(out ppView);
         }
 
         public int GetLastActiveView(out IVsTextView ppView) {

--- a/Tests/MockVsTests/MockVsServiceProvider.cs
+++ b/Tests/MockVsTests/MockVsServiceProvider.cs
@@ -27,10 +27,13 @@ using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 namespace Microsoft.VisualStudioTools.MockVsTests {
     [Export(typeof(SVsServiceProvider))]
     [Export(typeof(MockVsServiceProvider))]
-    public class MockVsServiceProvider : SVsServiceProvider, IOleServiceProvider, IServiceContainer {
+    public class MockVsServiceProvider : SVsServiceProvider, IOleServiceProvider, IServiceContainer, IDisposable {
         private readonly MockVs _vs;
-        private Dictionary<Type, object> _servicesByType = new Dictionary<Type, object>();
-        private Dictionary<Guid, object> _servicesByGuid = new Dictionary<Guid, object>();
+        private readonly Dictionary<Type, object> _servicesByType = new Dictionary<Type, object>();
+        private readonly Dictionary<Guid, object> _servicesByGuid = new Dictionary<Guid, object>();
+        private readonly Dictionary<Type, ServiceCreatorCallback> _serviceCreatorByType = new Dictionary<Type, ServiceCreatorCallback>();
+        private readonly List<IDisposable> _disposeAtEnd = new List<IDisposable>();
+        private bool _isDisposed;
 
         [ImportingConstructor]
         public MockVsServiceProvider(MockVs mockVs) {
@@ -66,6 +69,17 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
                 return res;
             }
 
+            ServiceCreatorCallback creator;
+            if (_serviceCreatorByType.TryGetValue(serviceType, out creator)) {
+                _servicesByType[serviceType] = res = creator(this, serviceType);
+                _serviceCreatorByType.Remove(serviceType);
+                var disposable = res as IDisposable;
+                if (disposable != null) {
+                    _disposeAtEnd.Add(disposable);
+                }
+                return res;
+            }
+
             Console.WriteLine("Unknown service: " + serviceType.FullName);
             return null;
         }
@@ -87,21 +101,36 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         }
 
         public void AddService(Type serviceType, ServiceCreatorCallback callback, bool promote) {
-            AddService(serviceType, callback(this, serviceType), promote);
+            _serviceCreatorByType[serviceType] = callback;
         }
 
         public void AddService(Type serviceType, ServiceCreatorCallback callback) {
-            AddService(serviceType, callback(this, serviceType));
+            _serviceCreatorByType[serviceType] = callback;
         }
 
         public void RemoveService(Type serviceType, bool promote) {
             _servicesByType.Remove(serviceType);
             _servicesByGuid.Remove(serviceType.GUID);
+            _serviceCreatorByType.Remove(serviceType);
         }
 
         public void RemoveService(Type serviceType) {
             _servicesByType.Remove(serviceType);
             _servicesByGuid.Remove(serviceType.GUID);
+            _serviceCreatorByType.Remove(serviceType);
+        }
+
+        public void Dispose() {
+            if (!_isDisposed) {
+                _isDisposed = true;
+                foreach (var d in _disposeAtEnd) {
+                    d.Dispose();
+                }
+                _disposeAtEnd.Clear();
+                _servicesByType.Clear();
+                _servicesByGuid.Clear();
+                _serviceCreatorByType.Clear();
+            }
         }
     }
 }

--- a/Tests/MockVsTests/MockVsTests.csproj
+++ b/Tests/MockVsTests/MockVsTests.csproj
@@ -92,6 +92,7 @@
     </Compile>
     <Compile Include="CachedVsInfo.cs" />
     <Compile Include="CommandTargetExtensions.cs" />
+    <Compile Include="MockClassifierAggregatorService.cs" />
     <Compile Include="MockDTEProperties.cs" />
     <Compile Include="MockDTEProperty.cs" />
     <Compile Include="HierarchyExtensions.cs" />


### PR DESCRIPTION
Fixes #4 Memory leaks in mock tests
The main causes were:
* TaskProvider.Worker not being correctly terminated
* CodeWindowManager having static caches
* MockVsServiceProvider not disposing services (not necessary within VS, but we need it for tests)
* Events not being unhooked and unnecessary closures