### PR TITLE
Fixes #8 SolutionExplorerTree.FindChildOfProject fails if you don't provide a child

### DIFF
--- a/Tests/Utilities.UI/UI/SolutionExplorerTree.cs
+++ b/Tests/Utilities.UI/UI/SolutionExplorerTree.cs
@@ -151,11 +151,11 @@ namespace TestUtilities.UI {
             }
             var projElement = projElements.Cast<AutomationElement>().Single();
 
-            var itemElement = FindNode(
+            var itemElement = path.Any() ? FindNode(
                 projElement.FindAll(TreeScope.Children, Condition.TrueCondition),
                 path,
                 0
-            );
+            ) : projElement;
 
             if (assertOnFailure) {
                 AutomationWrapper.DumpElement(Element);


### PR DESCRIPTION
Fixes #8 SolutionExplorerTree.FindChildOfProject fails if you don't provide a child
Adds check for empty path array.