### PR TITLE
Fixes #7 Mock tests do not correctly handle shutdown/UIThreadBase

### DIFF
--- a/Product/SharedProject/VsExtensions.cs
+++ b/Product/SharedProject/VsExtensions.cs
@@ -100,7 +100,15 @@ namespace Microsoft.VisualStudioTools {
             var uiThread = (UIThreadBase)serviceProvider.GetService(typeof(UIThreadBase));
             if (uiThread == null) {
                 Trace.TraceWarning("Returning NoOpUIThread instance from GetUIThread");
-                Debug.Assert(VsShellUtil.ShellIsShuttingDown, "No UIThread service but shell is not shutting down");
+#if DEBUG
+                var shell = (IVsShell)serviceProvider.GetService(typeof(SVsShell));
+                object shutdownStarted;
+                if (shell != null &&
+                    ErrorHandler.Succeeded(shell.GetProperty((int)__VSSPROPID6.VSSPROPID_ShutdownStarted, out shutdownStarted)) &&
+                    !(bool)shutdownStarted) {
+                    Debug.Fail("No UIThread service but shell is not shutting down");
+                }
+#endif
                 return new NoOpUIThread();
             }
             return uiThread;

--- a/Tests/MockVsTests/MockClassifierAggregatorService.cs
+++ b/Tests/MockVsTests/MockClassifierAggregatorService.cs
@@ -1,0 +1,74 @@
+﻿/* ****************************************************************************
+ *
+ * Copyright (c) Microsoft Corporation. 
+ *
+ * This source code is subject to terms and conditions of the Apache License, Version 2.0. A 
+ * copy of the license can be found in the License.html file at the root of this distribution. If 
+ * you cannot locate the Apache License, Version 2.0, please send an email to 
+ * vspython@microsoft.com. By using this source code in any fashion, you are agreeing to be bound 
+ * by the terms of the Apache License, Version 2.0.
+ *
+ * You must not remove this notice, or any other, from this software.
+ *
+ * ***************************************************************************/
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+
+namespace Microsoft.VisualStudioTools.MockVsTests {
+    [Export(typeof(IClassifierAggregatorService))]
+    public class MockClassifierAggregatorService : IClassifierAggregatorService {
+        [ImportMany]
+        internal IEnumerable<Lazy<IClassifierProvider, IContentTypeMetadata>> _providers = null;
+        
+        public IClassifier GetClassifier(ITextBuffer textBuffer) {
+            if (_providers == null) {
+                return null;
+            }
+
+            var contentType = textBuffer.ContentType;
+            return new AggregatedClassifier(
+                textBuffer,
+                _providers.Where(e => e.Metadata.ContentTypes.Any(c => contentType.IsOfType(c)))
+                    .Select(e => e.Value)
+            );
+        }
+
+        sealed class AggregatedClassifier : IClassifier, IDisposable {
+            private readonly ITextBuffer _buffer;
+            private readonly List<IClassifier> _classifiers;
+
+            public AggregatedClassifier(ITextBuffer textBuffer, IEnumerable<IClassifierProvider> providers) {
+                _buffer = textBuffer;
+                _classifiers = providers.Select(p => p.GetClassifier(_buffer)).ToList();
+            }
+
+            public void Dispose() {
+                foreach (var c in _classifiers.OfType<IDisposable>()) {
+                    c.Dispose();
+                }
+            }
+
+            public event EventHandler<ClassificationChangedEventArgs> ClassificationChanged {
+                add {
+                    foreach (var c in _classifiers) {
+                        c.ClassificationChanged += value;
+                    }
+                }
+                remove {
+                    foreach (var c in _classifiers) {
+                        c.ClassificationChanged -= value;
+                    }
+                }
+            }
+
+            public IList<ClassificationSpan> GetClassificationSpans(SnapshotSpan span) {
+                return _classifiers.SelectMany(c => c.GetClassificationSpans(span)).ToList();
+            }
+        }
+    }
+}

--- a/Tests/MockVsTests/MockCodeWindow.cs
+++ b/Tests/MockVsTests/MockCodeWindow.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         }
 
         public int GetEditorCaption(READONLYSTATUS dwReadOnly, out string pbstrEditorCaption) {
-            throw new NotImplementedException();
+            return GetPrimaryView(out ppView);
         }
 
         public int GetLastActiveView(out IVsTextView ppView) {

--- a/Tests/MockVsTests/MockVs.cs
+++ b/Tests/MockVsTests/MockVs.cs
@@ -148,6 +148,7 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
 
         public void Dispose() {
             _shutdown = true;
+            Shell.SetProperty((int)__VSSPROPID6.VSSPROPID_ShutdownStarted, true);
             _uiEvent.Set();
             if (!UIThread.Join(TimeSpan.FromSeconds(30))) {
                 Console.WriteLine("Failed to wait for UI thread to terminate");

--- a/Tests/MockVsTests/MockVsServiceProvider.cs
+++ b/Tests/MockVsTests/MockVsServiceProvider.cs
@@ -27,10 +27,13 @@ using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 namespace Microsoft.VisualStudioTools.MockVsTests {
     [Export(typeof(SVsServiceProvider))]
     [Export(typeof(MockVsServiceProvider))]
-    public class MockVsServiceProvider : SVsServiceProvider, IOleServiceProvider, IServiceContainer {
+    public class MockVsServiceProvider : SVsServiceProvider, IOleServiceProvider, IServiceContainer, IDisposable {
         private readonly MockVs _vs;
-        private Dictionary<Type, object> _servicesByType = new Dictionary<Type, object>();
-        private Dictionary<Guid, object> _servicesByGuid = new Dictionary<Guid, object>();
+        private readonly Dictionary<Type, object> _servicesByType = new Dictionary<Type, object>();
+        private readonly Dictionary<Guid, object> _servicesByGuid = new Dictionary<Guid, object>();
+        private readonly Dictionary<Type, ServiceCreatorCallback> _serviceCreatorByType = new Dictionary<Type, ServiceCreatorCallback>();
+        private readonly List<IDisposable> _disposeAtEnd = new List<IDisposable>();
+        private bool _isDisposed;
 
         [ImportingConstructor]
         public MockVsServiceProvider(MockVs mockVs) {
@@ -66,6 +69,17 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
                 return res;
             }
 
+            ServiceCreatorCallback creator;
+            if (_serviceCreatorByType.TryGetValue(serviceType, out creator)) {
+                _servicesByType[serviceType] = res = creator(this, serviceType);
+                _serviceCreatorByType.Remove(serviceType);
+                var disposable = res as IDisposable;
+                if (disposable != null) {
+                    _disposeAtEnd.Add(disposable);
+                }
+                return res;
+            }
+
             Console.WriteLine("Unknown service: " + serviceType.FullName);
             return null;
         }
@@ -87,21 +101,36 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         }
 
         public void AddService(Type serviceType, ServiceCreatorCallback callback, bool promote) {
-            AddService(serviceType, callback(this, serviceType), promote);
+            _serviceCreatorByType[serviceType] = callback;
         }
 
         public void AddService(Type serviceType, ServiceCreatorCallback callback) {
-            AddService(serviceType, callback(this, serviceType));
+            _serviceCreatorByType[serviceType] = callback;
         }
 
         public void RemoveService(Type serviceType, bool promote) {
             _servicesByType.Remove(serviceType);
             _servicesByGuid.Remove(serviceType.GUID);
+            _serviceCreatorByType.Remove(serviceType);
         }
 
         public void RemoveService(Type serviceType) {
             _servicesByType.Remove(serviceType);
             _servicesByGuid.Remove(serviceType.GUID);
+            _serviceCreatorByType.Remove(serviceType);
+        }
+
+        public void Dispose() {
+            if (!_isDisposed) {
+                _isDisposed = true;
+                foreach (var d in _disposeAtEnd) {
+                    d.Dispose();
+                }
+                _disposeAtEnd.Clear();
+                _servicesByType.Clear();
+                _servicesByGuid.Clear();
+                _serviceCreatorByType.Clear();
+            }
         }
     }
 }

--- a/Tests/MockVsTests/MockVsShell.cs
+++ b/Tests/MockVsTests/MockVsShell.cs
@@ -13,11 +13,14 @@
  * ***************************************************************************/
 
 using System;
+using System.Collections.Generic;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudioTools.MockVsTests {
     class MockVsShell : IVsShell {
+        private readonly Dictionary<int, object> _properties = new Dictionary<int, object>();
+
         public int AdviseBroadcastMessages(IVsBroadcastMessageEvents pSink, out uint pdwCookie) {
             throw new NotImplementedException();
         }
@@ -31,8 +34,7 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         }
 
         public int GetProperty(int propid, out object pvar) {
-            pvar = null;
-            return VSConstants.E_FAIL;
+            return _properties.TryGetValue(propid, out pvar) ? VSConstants.S_OK : VSConstants.E_FAIL;
         }
 
         public int IsPackageInstalled(ref Guid guidPackage, out int pfInstalled) {
@@ -56,7 +58,8 @@ namespace Microsoft.VisualStudioTools.MockVsTests {
         }
 
         public int SetProperty(int propid, object var) {
-            throw new NotImplementedException();
+            _properties[propid] = var;
+            return VSConstants.S_OK;
         }
 
         public int UnadviseBroadcastMessages(uint dwCookie) {

--- a/Tests/MockVsTests/MockVsTests.csproj
+++ b/Tests/MockVsTests/MockVsTests.csproj
@@ -92,6 +92,7 @@
     </Compile>
     <Compile Include="CachedVsInfo.cs" />
     <Compile Include="CommandTargetExtensions.cs" />
+    <Compile Include="MockClassifierAggregatorService.cs" />
     <Compile Include="MockDTEProperties.cs" />
     <Compile Include="MockDTEProperty.cs" />
     <Compile Include="HierarchyExtensions.cs" />


### PR DESCRIPTION
Fixes #7 Mock tests do not correctly handle shutdown/UIThreadBase
Adds property support to MockVsShell
Changes GetUIThread to check current provider rather than global provider.

(Also depends on fix for #4 / PR #13)