### PR TITLE
Fixes #10 Mock repl windows not initialising correctly on VS 2015

### DIFF
--- a/Tests/Utilities/Mocks/MockReplWindow.cs
+++ b/Tests/Utilities/Mocks/MockReplWindow.cs
@@ -43,6 +43,8 @@ namespace TestUtilities.Mocks {
         private readonly string _contentType;
 
 #if DEV14_OR_LATER
+        private PropertyCollection _properties;
+
         public event EventHandler<SubmissionBufferAddedEventArgs> SubmissionBufferAdded {
             add {
             }
@@ -55,7 +57,7 @@ namespace TestUtilities.Mocks {
             _eval = eval;
             _contentType = contentType;
             _view = new MockTextView(new MockTextBuffer(String.Empty, contentType, filename: "text"));
-            _eval.Initialize(this);
+            _eval._Initialize(this);
         }
 
         public bool ShowAnsiCodes { get; set; }
@@ -100,7 +102,7 @@ namespace TestUtilities.Mocks {
 #if DEV14_OR_LATER
         public ITextBuffer OutputBuffer {
             get {
-                throw new NotImplementedException();
+                return _view.TextBuffer;
             }
         }
 
@@ -142,7 +144,10 @@ namespace TestUtilities.Mocks {
 
         public PropertyCollection Properties {
             get {
-                throw new NotImplementedException();
+                if (_properties == null) {
+                    _properties = new PropertyCollection();
+                }
+                return _properties;
             }
         }
 #endif
@@ -284,7 +289,9 @@ namespace TestUtilities.Mocks {
         }
 
         Span IReplWindow.WriteLine(string text) {
-            throw new NotImplementedException();
+            var start = _output.Length;
+            _output.AppendLine(text);
+            return new Span(start, _output.Length - start);
         }
 
         public Task SubmitAsync(IEnumerable<string> inputs) {
@@ -292,7 +299,9 @@ namespace TestUtilities.Mocks {
         }
 
         public Span Write(string text) {
-            throw new NotImplementedException();
+            var start = _output.Length;
+            _output.Append(text);
+            return new Span(start, _output.Length - start);
         }
 
         public void Write(UIElement element) {
@@ -320,9 +329,9 @@ namespace TestUtilities.Mocks {
         #endregion
     }
 
-#if DEV14_OR_LATER
     public static class ReplEvalExtensions {
-        public static Task<ExecutionResult> Initialize(this IReplEvaluator self, IReplWindow window) {
+#if DEV14_OR_LATER
+        public static Task<ExecutionResult> _Initialize(this IReplEvaluator self, IReplWindow window) {
             self.CurrentWindow = window;
             return self.InitializeAsync();
         }
@@ -334,6 +343,10 @@ namespace TestUtilities.Mocks {
         public static Task<ExecutionResult> Reset(this IReplEvaluator self) {
             return self.ResetAsync();
         }
-    }
+#else
+        public static Task<ExecutionResult> _Initialize(this IReplEvaluator self, IReplWindow window) {
+            return self.Initialize(window);
+        }
 #endif
+    }
 }

--- a/Tests/Utilities/Mocks/MockServiceProvider.cs
+++ b/Tests/Utilities/Mocks/MockServiceProvider.cs
@@ -15,11 +15,17 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
+using Microsoft.VisualStudio.ComponentModelHost;
 
 namespace TestUtilities.Mocks {
     public class MockServiceProvider : IServiceProvider, IServiceContainer {
         public readonly Dictionary<Guid, object> Services = new Dictionary<Guid, object>();
-        
+        public readonly MockComponentModel ComponentModel = new MockComponentModel();
+
+        public MockServiceProvider() {
+            Services[typeof(SComponentModel).GUID] = ComponentModel;
+        }
+
         public object GetService(Type serviceType) {
             object service;
             Console.WriteLine("MockServiceProvider.GetService({0})", serviceType.Name);

--- a/Tests/Utilities/Mocks/MockTextOptions.cs
+++ b/Tests/Utilities/Mocks/MockTextOptions.cs
@@ -14,41 +14,36 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
 namespace TestUtilities.Mocks {
     public class MockTextOptions : IEditorOptions {
+        private readonly Dictionary<string, object> _options = new Dictionary<string, object> {
+            { DefaultOptions.ConvertTabsToSpacesOptionName, true },
+            { DefaultOptions.IndentSizeOptionName, 4 },
+            { DefaultOptions.NewLineCharacterOptionName, "\r\n" },
+            { DefaultOptions.TabSizeOptionName, 4 }
+        };
+
         public bool ClearOptionValue<T>(EditorOptionKey<T> key) {
-            throw new NotImplementedException();
+            return _options.Remove(key.Name);
         }
 
         public bool ClearOptionValue(string optionId) {
-            throw new NotImplementedException();
+            return _options.Remove(optionId);
         }
 
         public object GetOptionValue(string optionId) {
-            if (optionId == DefaultOptions.ConvertTabsToSpacesOptionId.Name) {
-                return true;
-            } else if (optionId == DefaultOptions.IndentSizeOptionId.Name) {
-                return 4;
+            object value;
+            if (_options.TryGetValue(optionId, out value)) {
+                return value;
             }
 
             throw new InvalidOperationException();
         }
 
         public T GetOptionValue<T>(EditorOptionKey<T> key) {
-            if (key.Equals(DefaultOptions.ConvertTabsToSpacesOptionId)) {
-                return (T)(object)true;
-            } else if (key.Equals(DefaultOptions.IndentSizeOptionId)) {
-                return (T)(object)4;
-            } else if (key.Equals(DefaultOptions.NewLineCharacterOptionId)) {
-                return (T)(object)"\r\n";
-            } else if (key.Equals(DefaultOptions.TabSizeOptionId)) {
-                return (T)(object)4;
-            }
-            throw new InvalidOperationException();
+            return (T)GetOptionValue(key.Name);
         }
 
         public T GetOptionValue<T>(string optionId) {
@@ -56,37 +51,41 @@ namespace TestUtilities.Mocks {
         }
 
         public IEditorOptions GlobalOptions {
-            get { throw new NotImplementedException(); }
+            get {
+                IEditorOptions opt = this;
+                while (opt.Parent != null) {
+                    opt = opt.Parent;
+                }
+                return opt;
+            }
         }
 
         public bool IsOptionDefined<T>(EditorOptionKey<T> key, bool localScopeOnly) {
-            throw new NotImplementedException();
+            return IsOptionDefined(key.Name, localScopeOnly);
         }
 
         public bool IsOptionDefined(string optionId, bool localScopeOnly) {
-            throw new NotImplementedException();
+            if (localScopeOnly || Parent == null) {
+                return _options.ContainsKey(optionId);
+            }
+
+            return _options.ContainsKey(optionId) || Parent.IsOptionDefined(optionId, false);
         }
 
-        public event EventHandler<EditorOptionChangedEventArgs> OptionChanged {
-            add { }
-            remove { }
-        }
+        public event EventHandler<EditorOptionChangedEventArgs> OptionChanged;
 
-        public IEditorOptions Parent {
-            get {
-                throw new NotImplementedException();
-            }
-            set {
-                throw new NotImplementedException();
-            }
-        }
+        public IEditorOptions Parent { get; set; }
 
         public void SetOptionValue<T>(EditorOptionKey<T> key, T value) {
-            throw new NotImplementedException();
+            SetOptionValue(key.Name, value);
         }
 
         public void SetOptionValue(string optionId, object value) {
-            throw new NotImplementedException();
+            _options[optionId] = value;
+            var evt = OptionChanged;
+            if (evt != null) {
+                evt(this, new EditorOptionChangedEventArgs(optionId));
+            }
         }
 
         public IEnumerable<EditorOptionDefinition> SupportedOptions {


### PR DESCRIPTION
Fixes #10 Mock repl windows not initialising correctly on VS 2015
Adds more mocks to support REPL tests on VS 2015
Fixes initialisation.